### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,548 @@
+# NODE.js
+Slovakia
+Table of Contents
+
+Loading from node_modules Folders
+The module Object
+The Module Object
+Modules
+
+Stability: 2 - Stable
+In the Node.js module system, each file is treated as a separate module. For example, consider a file named foo.js:
+
+const circle = require('./circle.js');
+console.log(`The area of a circle of radius 4 is ${circle.area(4)}`);
+On the first line, foo.js loads the module circle.js that is in the same directory as foo.js.
+
+Here are the contents of circle.js:
+
+const { PI } = Math;
+
+exports.area = (r) => PI * r ** 2;
+
+exports.circumference = (r) => 2 * PI * r;
+The module circle.js has exported the functions area() and circumference(). Functions and objects are added to the root of a module by specifying additional properties on the special exports object.
+
+Variables local to the module will be private, because the module is wrapped in a function by Node.js (see module wrapper). In this example, the variable PI is private to circle.js.
+
+The module.exports property can be assigned a new value (such as a function or object).
+
+Below, bar.js makes use of the square module, which exports a Square class:
+
+const Square = require('./square.js');
+const mySquare = new Square(2);
+console.log(`The area of mySquare is ${mySquare.area()}`);
+The square module is defined in square.js:
+
+// assigning to exports will not modify module, must use module.exports
+module.exports = class Square {
+  constructor(width) {
+    this.width = width;
+  }
+
+  area() {
+    return this.width ** 2;
+  }
+};
+The module system is implemented in the require('module') module.
+
+Accessing the main module
+
+When a file is run directly from Node.js, require.main is set to its module. That means that it is possible to determine whether a file has been run directly by testing require.main === module.
+
+For a file foo.js, this will be true if run via node foo.js, but false if run by require('./foo').
+
+Because module provides a filename property (normally equivalent to __filename), the entry point of the current application can be obtained by checking require.main.filename.
+
+Addenda: Package Manager Tips
+
+The semantics of Node.js's require() function were designed to be general enough to support a number of reasonable directory structures. Package manager programs such as dpkg, rpm, and npm will hopefully find it possible to build native packages from Node.js modules without modification.
+
+Below we give a suggested directory structure that could work:
+
+Let's say that we wanted to have the folder at /usr/lib/node/<some-package>/<some-version> hold the contents of a specific version of a package.
+
+Packages can depend on one another. In order to install package foo, it may be necessary to install a specific version of package bar. The bar package may itself have dependencies, and in some cases, these may even collide or form cyclic dependencies.
+
+Since Node.js looks up the realpath of any modules it loads (that is, resolves symlinks), and then looks for their dependencies in the node_modules folders as described here, this situation is very simple to resolve with the following architecture:
+
+/usr/lib/node/foo/1.2.3/ - Contents of the foo package, version 1.2.3.
+/usr/lib/node/bar/4.3.2/ - Contents of the bar package that foo depends on.
+/usr/lib/node/foo/1.2.3/node_modules/bar - Symbolic link to /usr/lib/node/bar/4.3.2/.
+/usr/lib/node/bar/4.3.2/node_modules/* - Symbolic links to the packages that bar depends on.
+Thus, even if a cycle is encountered, or if there are dependency conflicts, every module will be able to get a version of its dependency that it can use.
+
+When the code in the foo package does require('bar'), it will get the version that is symlinked into /usr/lib/node/foo/1.2.3/node_modules/bar. Then, when the code in the bar package calls require('quux'), it'll get the version that is symlinked into /usr/lib/node/bar/4.3.2/node_modules/quux.
+
+Furthermore, to make the module lookup process even more optimal, rather than putting packages directly in /usr/lib/node, we could put them in /usr/lib/node_modules/<name>/<version>. Then Node.js will not bother looking for missing dependencies in /usr/node_modules or /node_modules.
+
+In order to make modules available to the Node.js REPL, it might be useful to also add the /usr/lib/node_modules folder to the $NODE_PATH environment variable. Since the module lookups using node_modules folders are all relative, and based on the real path of the files making the calls to require(), the packages themselves can be anywhere.
+
+All Together...
+
+To get the exact filename that will be loaded when require() is called, use the require.resolve() function.
+
+Putting together all of the above, here is the high-level algorithm in pseudocode of what require.resolve() does:
+
+require(X) from module at path Y
+1. If X is a core module,
+   a. return the core module
+   b. STOP
+2. If X begins with '/'
+   a. set Y to be the filesystem root
+3. If X begins with './' or '/' or '../'
+   a. LOAD_AS_FILE(Y + X)
+   b. LOAD_AS_DIRECTORY(Y + X)
+4. LOAD_NODE_MODULES(X, dirname(Y))
+5. THROW "not found"
+
+LOAD_AS_FILE(X)
+1. If X is a file, load X as JavaScript text.  STOP
+2. If X.js is a file, load X.js as JavaScript text.  STOP
+3. If X.json is a file, parse X.json to a JavaScript Object.  STOP
+4. If X.node is a file, load X.node as binary addon.  STOP
+
+LOAD_INDEX(X)
+1. If X/index.js is a file, load X/index.js as JavaScript text.  STOP
+2. If X/index.json is a file, parse X/index.json to a JavaScript object. STOP
+3. If X/index.node is a file, load X/index.node as binary addon.  STOP
+
+LOAD_AS_DIRECTORY(X)
+1. If X/package.json is a file,
+   a. Parse X/package.json, and look for "main" field.
+   b. let M = X + (json main field)
+   c. LOAD_AS_FILE(M)
+   d. LOAD_INDEX(M)
+2. LOAD_INDEX(X)
+
+LOAD_NODE_MODULES(X, START)
+1. let DIRS=NODE_MODULES_PATHS(START)
+2. for each DIR in DIRS:
+   a. LOAD_AS_FILE(DIR/X)
+   b. LOAD_AS_DIRECTORY(DIR/X)
+
+NODE_MODULES_PATHS(START)
+1. let PARTS = path split(START)
+2. let I = count of PARTS - 1
+3. let DIRS = []
+4. while I >= 0,
+   a. if PARTS[I] = "node_modules" CONTINUE
+   b. DIR = path join(PARTS[0 .. I] + "node_modules")
+   c. DIRS = DIRS + DIR
+   d. let I = I - 1
+5. return DIRS
+Caching
+
+Modules are cached after the first time they are loaded. This means (among other things) that every call to require('foo') will get exactly the same object returned, if it would resolve to the same file.
+
+Multiple calls to require('foo') may not cause the module code to be executed multiple times. This is an important feature. With it, "partially done" objects can be returned, thus allowing transitive dependencies to be loaded even when they would cause cycles.
+
+To have a module execute code multiple times, export a function, and call that function.
+
+Module Caching Caveats
+
+Modules are cached based on their resolved filename. Since modules may resolve to a different filename based on the location of the calling module (loading from node_modules folders), it is not a guarantee that require('foo') will always return the exact same object, if it would resolve to different files.
+
+Additionally, on case-insensitive file systems or operating systems, different resolved filenames can point to the same file, but the cache will still treat them as different modules and will reload the file multiple times. For example, require('./foo') and require('./FOO') return two different objects, irrespective of whether or not ./foo and ./FOO are the same file.
+
+Core Modules
+
+Node.js has several modules compiled into the binary. These modules are described in greater detail elsewhere in this documentation.
+
+The core modules are defined within Node.js's source and are located in the lib/ folder.
+
+Core modules are always preferentially loaded if their identifier is passed to require(). For instance, require('http') will always return the built in HTTP module, even if there is a file by that name.
+
+Cycles
+
+When there are circular require() calls, a module might not have finished executing when it is returned.
+
+Consider this situation:
+
+a.js:
+
+console.log('a starting');
+exports.done = false;
+const b = require('./b.js');
+console.log('in a, b.done = %j', b.done);
+exports.done = true;
+console.log('a done');
+b.js:
+
+console.log('b starting');
+exports.done = false;
+const a = require('./a.js');
+console.log('in b, a.done = %j', a.done);
+exports.done = true;
+console.log('b done');
+main.js:
+
+console.log('main starting');
+const a = require('./a.js');
+const b = require('./b.js');
+console.log('in main, a.done = %j, b.done = %j', a.done, b.done);
+When main.js loads a.js, then a.js in turn loads b.js. At that point, b.js tries to load a.js. In order to prevent an infinite loop, an unfinished copy of the a.js exports object is returned to the b.js module. b.js then finishes loading, and its exports object is provided to the a.js module.
+
+By the time main.js has loaded both modules, they're both finished. The output of this program would thus be:
+
+$ node main.js
+main starting
+a starting
+b starting
+in b, a.done = false
+b done
+in a, b.done = true
+a done
+in main, a.done = true, b.done = true
+Careful planning is required to allow cyclic module dependencies to work correctly within an application.
+
+File Modules
+
+If the exact filename is not found, then Node.js will attempt to load the required filename with the added extensions: .js, .json, and finally .node.
+
+.js files are interpreted as JavaScript text files, and .json files are parsed as JSON text files. .node files are interpreted as compiled addon modules loaded with dlopen.
+
+A required module prefixed with '/' is an absolute path to the file. For example, require('/home/marco/foo.js') will load the file at /home/marco/foo.js.
+
+A required module prefixed with './' is relative to the file calling require(). That is, circle.js must be in the same directory as foo.js for require('./circle') to find it.
+
+Without a leading '/', './', or '../' to indicate a file, the module must either be a core module or is loaded from a node_modules folder.
+
+If the given path does not exist, require() will throw an Error with its code property set to 'MODULE_NOT_FOUND'.
+
+Folders as Modules
+
+It is convenient to organize programs and libraries into self-contained directories, and then provide a single entry point to that library. There are three ways in which a folder may be passed to require() as an argument.
+
+The first is to create a package.json file in the root of the folder, which specifies a main module. An example package.json file might look like this:
+
+{ "name" : "some-library",
+  "main" : "./lib/some-library.js" }
+If this was in a folder at ./some-library, then require('./some-library') would attempt to load ./some-library/lib/some-library.js.
+
+This is the extent of Node.js's awareness of package.json files.
+
+If the file specified by the 'main' entry of package.json is missing and can not be resolved, Node.js will report the entire module as missing with the default error:
+
+Error: Cannot find module 'some-library'
+If there is no package.json file present in the directory, then Node.js will attempt to load an index.js or index.node file out of that directory. For example, if there was no package.json file in the above example, then require('./some-library') would attempt to load:
+
+./some-library/index.js
+./some-library/index.node
+Loading from node_modules Folders
+
+If the module identifier passed to require() is not a core module, and does not begin with '/', '../', or './', then Node.js starts at the parent directory of the current module, and adds /node_modules, and attempts to load the module from that location. Node will not append node_modules to a path already ending in node_modules.
+
+If it is not found there, then it moves to the parent directory, and so on, until the root of the file system is reached.
+
+For example, if the file at '/home/ry/projects/foo.js' called require('bar.js'), then Node.js would look in the following locations, in this order:
+
+/home/ry/projects/node_modules/bar.js
+/home/ry/node_modules/bar.js
+/home/node_modules/bar.js
+/node_modules/bar.js
+This allows programs to localize their dependencies, so that they do not clash.
+
+It is possible to require specific files or sub modules distributed with a module by including a path suffix after the module name. For instance require('example-module/path/to/file') would resolve path/to/file relative to where example-module is located. The suffixed path follows the same module resolution semantics.
+
+Loading from the global folders
+
+If the NODE_PATH environment variable is set to a colon-delimited list of absolute paths, then Node.js will search those paths for modules if they are not found elsewhere.
+
+On Windows, NODE_PATH is delimited by semicolons (;) instead of colons.
+
+NODE_PATH was originally created to support loading modules from varying paths before the current module resolution algorithm was frozen.
+
+NODE_PATH is still supported, but is less necessary now that the Node.js ecosystem has settled on a convention for locating dependent modules. Sometimes deployments that rely on NODE_PATH show surprising behavior when people are unaware that NODE_PATH must be set. Sometimes a module's dependencies change, causing a different version (or even a different module) to be loaded as the NODE_PATH is searched.
+
+Additionally, Node.js will search in the following locations:
+
+1: $HOME/.node_modules
+2: $HOME/.node_libraries
+3: $PREFIX/lib/node
+Where $HOME is the user's home directory, and $PREFIX is Node.js's configured node_prefix.
+
+These are mostly for historic reasons.
+
+It is strongly encouraged to place dependencies in the local node_modules folder. These will be loaded faster, and more reliably.
+
+The module wrapper
+
+Before a module's code is executed, Node.js will wrap it with a function wrapper that looks like the following:
+
+(function(exports, require, module, __filename, __dirname) {
+// Module code actually lives in here
+});
+By doing this, Node.js achieves a few things:
+
+It keeps top-level variables (defined with var, const or let) scoped to the module rather than the global object.
+It helps to provide some global-looking variables that are actually specific to the module, such as:
+The module and exports objects that the implementor can use to export values from the module.
+The convenience variables __filename and __dirname, containing the module's absolute filename and directory path.
+The module scope
+
+__dirname
+
+Added in: v0.1.27
+
+<string>
+The directory name of the current module. This is the same as the path.dirname() of the __filename.
+
+Example: running node example.js from /Users/mjr
+
+console.log(__dirname);
+// Prints: /Users/mjr
+console.log(path.dirname(__filename));
+// Prints: /Users/mjr
+__filename
+
+Added in: v0.0.1
+
+<string>
+The file name of the current module. This is the resolved absolute path of the current module file.
+
+For a main program this is not necessarily the same as the file name used in the command line.
+
+See __dirname for the directory name of the current module.
+
+Examples:
+
+Running node example.js from /Users/mjr
+
+console.log(__filename);
+// Prints: /Users/mjr/example.js
+console.log(__dirname);
+// Prints: /Users/mjr
+Given two modules: a and b, where b is a dependency of a and there is a directory structure of:
+
+/Users/mjr/app/a.js
+/Users/mjr/app/node_modules/b/b.js
+References to __filename within b.js will return /Users/mjr/app/node_modules/b/b.js while references to __filename within a.js will return /Users/mjr/app/a.js.
+
+exports
+
+Added in: v0.1.12
+
+A reference to the module.exports that is shorter to type. See the section about the exports shortcut for details on when to use exports and when to use module.exports.
+
+module
+
+Added in: v0.1.16
+
+<Object>
+A reference to the current module, see the section about the module object. In particular, module.exports is used for defining what a module exports and makes available through require().
+
+require()
+
+Added in: v0.1.13
+
+<Function>
+To require modules.
+
+require.cache
+
+Added in: v0.3.0
+
+<Object>
+Modules are cached in this object when they are required. By deleting a key value from this object, the next require will reload the module. Note that this does not apply to native addons, for which reloading will result in an error.
+
+require.extensions
+
+Added in: v0.3.0Deprecated since: v0.10.6
+
+Stability: 0 - Deprecated
+<Object>
+Instruct require on how to handle certain file extensions.
+
+Process files with the extension .sjs as .js:
+
+require.extensions['.sjs'] = require.extensions['.js'];
+Deprecated In the past, this list has been used to load non-JavaScript modules into Node.js by compiling them on-demand. However, in practice, there are much better ways to do this, such as loading modules via some other Node.js program, or compiling them to JavaScript ahead of time.
+
+Since the module system is locked, this feature will probably never go away. However, it may have subtle bugs and complexities that are best left untouched.
+
+Note that the number of file system operations that the module system has to perform in order to resolve a require(...) statement to a filename scales linearly with the number of registered extensions.
+
+In other words, adding extensions slows down the module loader and should be discouraged.
+
+require.main
+
+Added in: v0.1.17
+
+<Object>
+The Module object representing the entry script loaded when the Node.js process launched. See "Accessing the main module".
+
+In entry.js script:
+
+console.log(require.main);
+node entry.js
+Module {
+  id: '.',
+  exports: {},
+  parent: null,
+  filename: '/absolute/path/to/entry.js',
+  loaded: false,
+  children: [],
+  paths:
+   [ '/absolute/path/to/node_modules',
+     '/absolute/path/node_modules',
+     '/absolute/node_modules',
+     '/node_modules' ] }
+require.resolve(request[, options])
+
+request <string> The module path to resolve.
+options <Object>
+paths <string[]> Paths to resolve module location from. If present, these paths are used instead of the default resolution paths. Note that each of these paths is used as a starting point for the module resolution algorithm, meaning that the node_modules hierarchy is checked from this location.
+Returns: <string>
+Use the internal require() machinery to look up the location of a module, but rather than loading the module, just return the resolved filename.
+
+require.resolve.paths(request)
+
+Added in: v8.9.0
+
+request <string> The module path whose lookup paths are being retrieved.
+Returns: <string[]> | <null>
+Returns an array containing the paths searched during resolution of request or null if the request string references a core module, for example http or fs.
+
+The module Object
+
+Added in: v0.1.16
+
+<Object>
+In each module, the module free variable is a reference to the object representing the current module. For convenience, module.exports is also accessible via the exports module-global. module is not actually a global but rather local to each module.
+
+module.children
+
+Added in: v0.1.16
+
+<module[]>
+The module objects required by this one.
+
+module.exports
+
+Added in: v0.1.16
+
+<Object>
+The module.exports object is created by the Module system. Sometimes this is not acceptable; many want their module to be an instance of some class. To do this, assign the desired export object to module.exports. Note that assigning the desired object to exports will simply rebind the local exports variable, which is probably not what is desired.
+
+For example suppose we were making a module called a.js:
+
+const EventEmitter = require('events');
+
+module.exports = new EventEmitter();
+
+// Do some work, and after some time emit
+// the 'ready' event from the module itself.
+setTimeout(() => {
+  module.exports.emit('ready');
+}, 1000);
+Then in another file we could do:
+
+const a = require('./a');
+a.on('ready', () => {
+  console.log('module "a" is ready');
+});
+Note that assignment to module.exports must be done immediately. It cannot be done in any callbacks. This does not work:
+
+x.js:
+
+setTimeout(() => {
+  module.exports = { a: 'hello' };
+}, 0);
+y.js:
+
+const x = require('./x');
+console.log(x.a);
+exports shortcut
+
+Added in: v0.1.16
+
+The exports variable is available within a module's file-level scope, and is assigned the value of module.exports before the module is evaluated.
+
+It allows a shortcut, so that module.exports.f = ... can be written more succinctly as exports.f = .... However, be aware that like any variable, if a new value is assigned to exports, it is no longer bound to module.exports:
+
+module.exports.hello = true; // Exported from require of module
+exports = { hello: false };  // Not exported, only available in the module
+When the module.exports property is being completely replaced by a new object, it is common to also reassign exports:
+
+module.exports = exports = function Constructor() {
+  // ... etc.
+};
+To illustrate the behavior, imagine this hypothetical implementation of require(), which is quite similar to what is actually done by require():
+
+function require(/* ... */) {
+  const module = { exports: {} };
+  ((module, exports) => {
+    // Module code here. In this example, define a function.
+    function someFunc() {}
+    exports = someFunc;
+    // At this point, exports is no longer a shortcut to module.exports, and
+    // this module will still export an empty default object.
+    module.exports = someFunc;
+    // At this point, the module will now export someFunc, instead of the
+    // default object.
+  })(module, module.exports);
+  return module.exports;
+}
+module.filename
+
+Added in: v0.1.16
+
+<string>
+The fully resolved filename to the module.
+
+module.id
+
+Added in: v0.1.16
+
+<string>
+The identifier for the module. Typically this is the fully resolved filename.
+
+module.loaded
+
+Added in: v0.1.16
+
+<boolean>
+Whether or not the module is done loading, or is in the process of loading.
+
+module.parent
+
+Added in: v0.1.16
+
+<module>
+The module that first required this one.
+
+module.paths
+
+Added in: v0.4.0
+
+<string[]>
+The search paths for the module.
+
+module.require(id)
+
+Added in: v0.5.1
+
+id <string>
+Returns: <Object> module.exports from the resolved module
+The module.require method provides a way to load a module as if require() was called from the original module.
+
+In order to do this, it is necessary to get a reference to the module object. Since require() returns the module.exports, and the module is typically only available within a specific module's code, it must be explicitly exported in order to be used.
+
+The Module Object
+
+Added in: v0.3.7
+
+<Object>
+Provides general utility methods when interacting with instances of Module — the module variable often seen in file modules. Accessed via require('module').
+
+module.builtinModules
+
+Added in: v9.3.0
+
+<string[]>
+A list of the names of all modules provided by Node.js. Can be used to verify if a module is maintained by a third party or not.
+
+Note that module in this context isn't the same object that's provided by the module wrapper. To access it, require the Module module:
+
+const builtin = require('module').builtinModules;


### PR DESCRIPTION
Obsah

Načítava sa zo zložiek node_modules
Modul Object
Objekt modulu
moduly

Stabilita: 2 - Stabilná
V module modulu Node.js sa každý súbor považuje za samostatný modul. Zvážte napríklad súbor s názvom foo.js:

const circle = vyžadovať ('./ circle.js');
console.log (`Oblasť kruhu polomeru 4 je $ {circle.area (4)}`);
Na prvom riadku foo.js načíta modul circle.js, ktorý je v rovnakom adresári ako foo.js.

Tu je obsah circle.js:

const {PI} = Matematika;

exports.area = (r) => PI * r ** 2;

exports.circumference = (r) => 2 * PI * r;
Modul circle.js exportoval oblasti funkcií () a obvodu (). Funkcie a objekty sa pridávajú do koreňa modulu zadaním ďalších vlastností na špeciálnom objekte exportu.

Premenné lokálne modulu budú súkromné, pretože modul je zabalený do funkcie pomocou Node.js (viď modul wrapper). V tomto príklade je premenná PI súkromná pre circle.js.

Vlastnosti modulu.exporty môže byť priradená nová hodnota (napríklad funkcia alebo objekt).

Nižšie, bar.js využíva štvorcový modul, ktorý exportuje triedu Square:

const Square = vyžadujú ('./ square.js');
const mySquare = nové štvorec (2);
console.log (`Oblasť mySquare je $ {mySquare.area ()}`);
Štvorcový modul je definovaný v square.js:

// pridelenie exportu nemodifikuje modul, musí používať modul.exports
module.exports = class Square {
  konštruktor (šírka) {
    this.width = width;
  }

  oblasť () {
    vrátiť túto šírku ** 2;
  }
};
Modulový systém je implementovaný v modulu (modul) modulu.

Prístup k hlavnému modulu

Keď je súbor spustený priamo z Node.js, require.main je nastavený na jeho modul. To znamená, že je možné určiť, či bol súbor spustený priamo testom modulu require.main ===.

Pre súbor foo.js to bude pravda, ak sa spustí cez uzol foo.js, ale falošný, ak je spustený požiadavkou ('./ foo').

Pretože modul poskytuje vlastnosť názvu súboru (zvyčajne ekvivalentná názvu __file), vstupný bod aktuálnej aplikácie je možné získať tak, že skontrolujete povinný názov súboru.main.file.

Addenda: Tipy pre správcu balíkov

Sémantika funkcie Node.js vyžadujú () boli navrhnuté tak, aby boli dostatočne všeobecné na podporu množstva primeraných štruktúr adresárov. Programy správcu balíkov, ako sú dpkg, rpm a npm, dúfajú, že bude možné vytvoriť natívne balíky z modulov Node.js bez úpravy.

Nižšie uvádzame navrhovanú štruktúru adresárov, ktorá by mohla fungovať:

Povedzme, že sme chceli mať priečinok na / usr / lib / node / <some-package> / <some-version> obsahovať konkrétnu verziu balíka.

Balíky môžu závisieť jeden od druhého. Ak chcete nainštalovať balík foo, môže byť potrebné inštalovať konkrétnu verziu balíka. Samotný balík balíkov môže mať závislosti a v niektorých prípadoch sa môžu dokonca zraziť alebo vytvárať cyklické závislosti.

Vzhľadom k tomu, Node.js hľadá realpath akékoľvek moduly, ktoré načíta (to znamená, že rieši symboly), a potom hľadá ich závislosti v priečinkoch node_modules, ako je tu popísané, táto situácia je veľmi jednoduché na vyriešenie pomocou nasledujúcej architektúry:

/usr/lib/node/foo/1.2.3/ - Obsah balíka foo, verzia 1.2.3.
/usr/lib/node/bar/4.3.2/ - Obsah balíka, ktorý závisí od foo.
/usr/lib/node/foo/1.2.3/node_modules/bar - Symbolický odkaz na /usr/lib/node/bar/4.3.2/.
/usr/lib/node/bar/4.3.2/node_modules/* - Symbolické odkazy na balíky, na ktorých závisí bar.
Takže aj keď sa vyskytne cyklus alebo ak sú konflikty závislosti, každý modul bude schopný získať verziu svojej závislosti, ktorú môže použiť.

Keď kód v balíčku foo nevyžaduje ('bar'), dostane sa verzia, ktorá je symlinkovaná do /usr/lib/node/foo/1.2.3/node_modules/bar. Potom, keď požaduje kód v barovom balíku volania ('quux'), dostane sa verzia, ktorá je symlinkovaná do /usr/lib/node/bar/4.3.2/node_modules/quux.

Navyše, aby sme proces vyhľadávania modulov ešte optimálni, namiesto toho, aby sme balíky umiestnili priamo do / usr / lib / node, mohli by sme ich vložiť do adresára / usr / lib / node_modules / <name> / <version>. Potom Node.js neobťažuje hľadanie chýbajúcich závislostí v / usr / node_modules alebo / node_modules.

Aby boli moduly dostupné pre REPL Node.js, môže byť užitočné pridať aj priečinok / usr / lib / node_modules do premennej prostredia $ NODE_PATH. Vzhľadom k tomu, že vyhľadávanie modulov pomocou priečinkov node_modules sú všetky relatívne a na základe skutočnej cesty súborov vyžadujúcich volanie (), samotné balíky môžu byť kdekoľvek.

Všetci spolu...

Ak chcete získať presný názov súboru, ktorý sa načíta pri požiadavke (), použite funkciu require.resolve ().

Spájajúc všetky vyššie uvedené, tu je algoritmus na vysokej úrovni v pseudokóde toho, čo vyžadujú.resolve ():

vyžadujú (X) z modulu na trase Y
1. Ak je X jadrový modul,
   a. vrátiť modul jadra
   b. STOP
2. Ak X začína s '/'
   a. nastavte Y ako koreňový súborový systém
3. Ak X začína znakom "./" alebo "/" alebo "../"
   a. LOAD_AS_FILE (Y + X)
   b. LOAD_AS_DIRECTORY (Y+ X)
4. LOAD_NODE_MODULES (X, dirname (Y))
5. THROW "nenašiel"

LOAD_AS_FILE (X)
1. Ak je X súbor, načítajte X ako text v jazyku JavaScript. STOP
2. Ak je X.js súbor, načítajte X.js ako text v jazyku JavaScript. STOP
3. Ak je X.json súbor, analyzujte X.json na objekt JavaScript. STOP
4. Ak je X.node súbor, načítajte X.node ako binárny addon. STOP

LOAD_INDEX (X)
1. Ak súbor X / index.js je súbor, načítajte X / index.js ako text v jazyku JavaScript. STOP
2. Ak súbor X / index.json je súbor, analyzujte X / index.json na objekt JavaScript. STOP
3. Ak súbor X / index.node je súbor, načítajte X / index.node ako binárny addon. STOP

LOAD_AS_DIRECTORY (X)
1. Ak súbor X / package.json je súbor,
   a. Parse X / package.json a vyhľadajte pole "main".
   b. nech M = X + (v hlavnom poli)
   c. LOAD_AS_FILE (M)
   d. LOAD_INDEX (M)
2. LOAD_INDEX (X)

LOAD_NODE_MODULES (X, START)
1. nechajte DIRS = NODE_MODULES_PATHS (START)
2. pre každý DIR v DIRS:
   a. LOAD_AS_FILE (DIR / X)
   b. LOAD_AS_DIRECTORY (DIR / X)

NODE_MODULES_PATHS (START)
1. nechajte PARTS = rozdelenie cesty (START)
2. nechajte I = počet častí - 1
3. nechajte DIRS = []
4. kým I> = 0,
   a. ak PARTS [I] = "node_modules" CONTINUE
   b. DIR = spojenie cesty (PARTS [0 .. I] + "node_modules")
   c. DIRS = DIRS + DIR
   d. Nech je I = I - 1
5. vrátiť DIRS
caching

Moduly sa ukladajú do vyrovnávacej pamäte po prvom načítaní. To znamená (okrem iného), že každé volanie vyžadujúce ("foo") získa presne ten istý vrátený objekt, ak by to vyriešilo k rovnakému súboru.

Viacnásobné volania vyžadujúce ("foo") nesmú spôsobiť, že kód modulu bude vykonaný viackrát. To je dôležitá vlastnosť. S ním môžu byť vrátené "čiastočne hotové" objekty, čo umožňuje načítať tranzitívne závislosti aj vtedy, keď spôsobia cykly.

Ak chcete modul spustiť kód viackrát, exportujte funkciu a zavolajte túto funkciu.

Modul Caching náhľad

Moduly sú uložené vo vyrovnávacej pamäti na základe ich vyriešeného názvu súboru. Vzhľadom na to, že moduly sa môžu rozdeliť na iný názov súboru na základe umiestnenia volajúceho modulu (načítanie z priečinkov node_modules), nie je to záruka, že vyžadujú ('foo') vždy vrátia presne ten istý objekt, ak by to vyriešil rôzne súbory ,

Okrem toho na súborových systémoch alebo operačných systémoch, ktoré nie sú citlivé na veľkosť malých a veľkých písmen, môžu rôzne názvy súborov vyriešené na rovnaký súbor, ale vyrovnávacia pamäť bude s nimi zaobchádzať ako s rôznymi modulmi a bude súbor načítať viackrát. Napríklad vyžadovať ('./ foo') a vyžadovať ('./ FOO') vrátiť dva rôzne objekty, bez ohľadu na to, či ./foo a ./FOO sú rovnaký súbor.

Core moduly

Node.js má niekoľko modulov zostavených do binárneho súboru. Tieto moduly sú podrobnejšie popísané inde v tejto dokumentácii.

Základné moduly sú definované v rámci zdroja Node.js a nachádzajú sa v priečinku lib /.

Moduly jadra sa vždy prednostne načítajú, ak ich identifikátor prechádza na požiadavku (). Napríklad požiadavka ('http') vždy vráti vstavaný modul HTTP, a to aj vtedy, ak existuje súbor s týmto názvom.

cykly

Ak existujú volania circular require (), mohol by byť modul po dokončení spúšťania nevykonaný.

Zvážte túto situáciu:

a.js:

console.log ("štart");
exports.done = false;
const b = vyžadujú ('./ b.js');
console.log ('v a, b.done =% j', b.done);
exports.done = true;
console.log ('hotovo');
b.js:

console.log ('b začína');
exports.done = false;
const a = vyžadovať ('./ a.js');
console.log ('v b, a.done =% j', a.done);
exports.done = true;
console.log ('b done');
main.js:

console.log ("hlavné spustenie");
const a = vyžadovať ('./ a.js');
const b = vyžadujú ('./ b.js');
console.log ('v hlavnom, a.done =% j, b.done =% j', a.done, b.done);
Keď main.js načíta a.js, potom a.js zase načíta b.js. V tomto bode sa b.js pokúša načítať a.js. Aby sa zabránilo nekonečnej slučke, nedokončená kópia objektu exportu a.js sa vráti do modulu b.js. b.js potom dokončí načítanie a jeho objekt exportu je poskytnutý modulu a.js.

V čase, keď main.js naplnil oba moduly, sú obaja dokončené. Výsledkom tohto programu by bolo:

$ node main.js
hlavné spustenie
štart
b štart
v b, a.done = false
b urobil
v a, b.done = true
hotovo
v hlavnom menu, a.done = true, b.done = true
Starostlivé plánovanie je potrebné, aby cyklické závislosti modulov fungovali správne v rámci aplikácie.

Súborové moduly

Ak presný názov súboru nie je nájdený, Node.js sa pokúsi načítať požadovaný názov súboru s pridanými rozšíreniami: .js, .json a nakoniec .node.

Súbory .js sa interpretujú ako textové súbory jazyka JavaScript a súbory .json sú analyzované ako textové súbory JSON. Súbory .node sa interpretujú ako kompilované addonové moduly načítané dlopenom.

Požadovaný modul s predponou '/' je absolútna cesta k súboru. Požadovať napríklad ('/ home / marco / foo.js') načíta súbor na /home/marco/foo.js.

Požadovaný modul s predponou "./" je relatívny vzhľadom na volanie súboru require (). To znamená, že circle.js musí byť v rovnakom adresári ako foo.js pre požiadavku ('./ kruh'), aby ste ju našli.

Bez vedenia '/', './' alebo '../' na označenie súboru musí byť modul buď základným modulom, alebo je načítaný z node_modules
zložky.

Ak daná cesta neexistuje, požiadavka () hodí chybu s vlastnosťou kódu nastavenou na 'MODULE_NOT_FOUND'.

Zložky ako moduly

Je vhodné organizovať programy a knižnice do samostatných adresárov a potom poskytnúť jediný vstupný bod tejto knižnici. Existujú tri spôsoby, ktorými môže byť zložka odovzdaná požiadavke () ako argument.

Prvým je vytvorenie súboru package.json v koreňovom adresári priečinka, ktorý špecifikuje hlavný modul. Príklad súboru package.json môže vyzerať takto:

{"name": "some-library",
  "main": "./lib/some-library.js"}
Ak by to bolo v priečinku na ./some-library, potom by ste si vyžadovali ('./ some-library') pokus o načítanie ./some-library/lib/some-library.js.

To je rozsah informovanosti Node.js o súboroch package.json.

Ak súbor zadaný príkazom 'main' balíka package.json chýba a nemožno ho vyriešiť, Node.js oznámi celý modul ako chybu s predvolenou chybou:

Chyba: Nie je možné nájsť modul 'some-library'
Ak v adresári nie je žiadny súbor package.json, Node.js sa pokúsi načítať súbor index.js alebo index.node z tohto adresára. Napríklad, ak vo vyššie uvedenom príklade nebol súbor package.json, potom by sa mal ('./ some-library') pokúsiť načítať:

./some-library/index.js
./some-library/index.node
Načítava sa zo zložiek node_modules

Ak identifikátor modulu prešiel požiadavkou () nie je jadrový modul a nezačína s '/', '../' alebo './', potom Node.js začína v nadradenom adresári aktuálneho modulu, a pridáva / node_modules a pokúša sa načítať modul z tohto miesta. Uzol nebude pridať node_modules na cestu, ktorá už končí v node_modules.

Ak sa tam nenachádza, presunie sa do nadradeného adresára atď., Kým sa nedosiahne koreň súborového systému.

Napríklad, ak súbor na '/home/ry/projects/foo.js' nazvaný vyžadujú ('bar.js'), potom Node.js by sa pozrel na nasledujúce miesta v tomto poradí:

/home/ry/projects/node_modules/bar.js
/home/ry/node_modules/bar.js
/home/node_modules/bar.js
/node_modules/bar.js
To umožňuje programom lokalizovať ich závislosť, aby nedochádzalo ku konfliktu.

Je možné požadovať špecifické súbory alebo submoduly distribuované modulom tak, že po názve modulu obsahuje príponu cesty. Napríklad požiadavka ('example-module / path / to / file') by vyriešila cestu / to / file vzhľadom k tomu, kde sa nachádza príkladový modul. Prípustná cesta sleduje rovnakú sémantiku rozlíšenia modulu.

Načítava sa z globálnych priečinkov

Ak je premenná prostredia NODE_PATH nastavená na zoznam absolútnych ciest vymedzený dvojbodkou, Node.js vyhľadá tieto cesty pre moduly, ak sa nenájdu inde.

V systéme Windows je NODE_PATH namiesto dvojbodiek vymedzený bodkočiarkami (;).

NODE_PATH bol pôvodne vytvorený na podporu načítania modulov z rôznych ciest pred zmrazením súčasného algoritmu rozlíšenia modulov.

NODE_PATH je stále podporovaná, je však menej potrebná, keď sa ekosystém Node.js vysporiadal s konvenciou na vyhľadávanie závislých modulov. Niekedy nasadenia, ktoré závisia od NODE_PATH, vykazujú prekvapujúce správanie, keď ľudia nevedia, že je potrebné nastaviť NODE_PATH. Niekedy sa zmena závislosti modulu spôsobuje načítanie inej verzie (alebo dokonca iného modulu) pri vyhľadávaní NODE_PATH.

Node.js navyše vyhľadá na nasledujúcich miestach:

1: $ HOME / .node_moduly
2: $ HOME / .node_libraries
3: $ PREFIX / lib / uzol
Kde $ HOME je domovský adresár používateľa a $ PREFIX je Node.js nakonfigurovaný node_prefix.

Ide väčšinou o historické dôvody.

Dôrazne sa odporúča umiestniť závislosti do lokálnej zložky node_modules. Tieto sa načítajú rýchlejšie a spoľahlivejšie.

Balík modulov

Pred spustením kódu modulu ho Node.js zabalí s balíkmi funkcií, ktoré vyzerajú takto:

(funkcia (export, požiadavka, modul, __filename, __dirname) {
Kód modulu skutočne žije tu
});
Týmto spôsobom dosiahne Node.js niekoľko vecí:

Udržiava premenné najvyššej úrovne (definované s var, const alebo let) zamerané na modul namiesto globálneho objektu.
Pomáha poskytovať niektoré globálne vyzerajúce premenné, ktoré sú vlastne špecifické pre modul, napríklad:
Modul exportuje objekty, ktoré implementátor môže použiť na export hodnôt z modulu.
Premenné komfortu __filename a __dirname, ktoré obsahujú absolútny názov súboru a cestu k adresáru modulu.
Rozsah modulu

__dirname

Pridané v: v0.1.27

<String>
Názov adresára aktuálneho modulu. Toto je rovnaké ako názov path.dir () názvu __file.

Príklad: behový uzol example.js z / Users / mjr

console.log (__ dirname);
// Výtlačky: / Users / mjr
console.log (path.dirname (__ súboru));
// Výtlačky: / Users / mjr
__názov súboru

Pridané v: v0.0.1

<String>
Názov súboru aktuálneho modulu. Toto je absolútna absolútna cesta aktuálneho súboru modulu.

Pre hlavný program to nemusí byť nevyhnutne rovnaké ako názov súboru použitý v príkazovom riadku.

Pozrite si __dirname pre názov adresára aktuálneho moDule.

Príklady:

Spúšťací uzol example.js z / Users / mjr

console.log (__ súboru);
// Vytlačí: /Users/mjr/example.js
console.log (__ dirname);
// Výtlačky: / Users / mjr
Vzhľadom na dva moduly: a a b, kde b je závislosť a a existuje štruktúra adresárov:

/Users/mjr/app/a.js
/Users/mjr/app/node_modules/b/b.js
Odkazy na súbor __filename v rámci b.js vrátia /Users/mjr/app/node_modules/b/b.js, kým odkazy na názov __file v rámci a.js sa vrátia /Users/mjr/app/a.js.

vývoz

Pridané v: v0.1.12

Odkaz na modul.exports, ktorý je kratší na zadávanie textu. Pozrite si sekciu o skratke pre export, kde nájdete podrobnosti o tom, kedy chcete použiť vývoz a kedy sa použije modul.exporty.

modul

Pridané v: v0.1.16

<Object>
Odkaz na aktuálny modul nájdete v časti o module modulu. Najmä modul.exports sa používa na definovanie toho, čo modul exportuje a sprístupňuje prostredníctvom požiadavky ().

vyžadujú ()

Pridané v: v0.1.13

<Funkcia>
Požadovať moduly.

require.cache

Pridané v: v0.3.0

<Object>
Moduly sa v tomto objekte ukladajú do vyrovnávacej pamäte, ak sú požadované. Odstránením kľúčovej hodnoty z tohto objektu bude nasledujúci požadovať opätovné načítanie modulu. Upozorňujeme, že to neplatí pre natívne addony, pri ktorých opätovné načítanie spôsobí chybu.

require.extensions

Pridané v: v0.3.0Dotazené od: v0.10.6

Stabilita: 0 - Zastaraná
<Object>
Pokyn požadovať, ako zvládnuť určité prípony súborov.

Spracovanie súborov s príponou .sjs ako .js:

require.extensions ['.sjs'] = vyžadujú rozšírenia ['. js'];
Zastarané V minulosti sa tento zoznam použil na načítanie modulov bez jazyka JavaScript do súboru Node.js ich zostavovaním na požiadanie. V praxi však existujú oveľa lepšie spôsoby, ako je napríklad načítavanie modulov pomocou nejakého iného programu Node.js alebo ich skompilovanie pred JavaScriptom.

Keďže systém modulov je uzamknutý, táto funkcia pravdepodobne nikdy nezmizne. Avšak, môže to mať jemné chyby a zložitosti, ktoré sú najlepšie nedotknuté.

Všimnite si, že počet operácií súborového systému, ktoré musí modulový systém vykonať, aby vyriešil požiadavku (...) na názov súboru, sa bude meniť lineárne s počtom registrovaných rozšírení.

Inými slovami, pridávanie rozšírení spomaľuje nakladač modulov a malo by sa zabrániť.

require.main

Pridané v: v0.1.17

<Object>
Objekt modulu predstavujúci vstupný skript načítaný pri spustení procesu Node.js. Pozrite si časť "Prístup k hlavnému modulu".

V skripte entry.js:

console.log (require.main);
uzol entry.js
Modul {
  id: ".",
  export: {},
  rodič: null,
  názov súboru: '/absolute/path/to/entry.js',
  naložené: falošné,
  deti: [],
  cesty:
   ['/ absolútna / cesta / do / node_moduly',
     '/ Absolútna / path / node_modules'
     '/ Absolútna / node_modules',
     '/ node_modules']}
require.resolve (vyžiadanie [, možnosti])

request <string> Modul cesta k vyriešeniu.
možnosti <Object>
cesty <reťazec []> Cesta na vyriešenie umiestnenia modulu z. Ak sú tieto cesty k dispozícii, namiesto predvolených ciest rozlíšenia. Všimnite si, že každá z týchto ciest sa používa ako východiskový bod pre algoritmus rozlíšenia modulov, čo znamená, že hierarchia node_modules je kontrolovaná z tohto miesta.
Vráti: <string>
Použite interný require () stroj aby vyhľadal miesto modulu, ale skôr ako načítať modul, len vrátiť vyriešený názov súboru.

require.resolve.paths (žiadosť)

Pridané v: v8.9.0

request <string> Cesta modulu, ktorej cesty vyhľadávania sú načítané.
Vráti: <string []> | <Null>
Vracia pole obsahujúce cesty vyhľadávané počas rozlíšenia požiadavky alebo null, ak reťazec požiadavky odkazuje na jadrový modul, napríklad http alebo fs.

Modul Object

Pridané v: v0.1.16

<Object>
V každom module je voľná premenná modulu odkazom na objekt reprezentujúci aktuálny modul. Pre pohodlie je modul.exports prístupný aj prostredníctvom modulu export-global. modul nie je v skutočnosti globálnym, ale skôr miestnym pre každý modul.

module.children

Pridané v: v0.1.16

<Modul []>
Modulové objekty požadované touto.

module.exports

Pridané v: v0.1.16

<Object>
Objekt modul.exports je vytvorený systémom modulov. Niekedy to nie je prijateľné; mnohí chcú, aby ich modul bol príkladom nejakej triedy. Za týmto účelom priraďte požadovaný objekt exportu do modulu export. Všimnite si, že priradenie požadovaného objektu exportom jednoducho znova vytvorí premennú lokálneho exportu, čo pravdepodobne nie je to, čo je požadované.

Predpokladajme napríklad, že sme vytvorili modul s názvom a.js:

const EventEmitter = vyžaduje ('udalosti');

module.exports = nový EventEmitter ();

Vykonajte nejakú prácu a po určitom čase vydáte
// udalosť 'ready' zo samotného modulu.
setTimeout (() => {
  module.exports.emit ( 'ready');
}, 1000);
Potom v inom súbore sme mohli urobiť:

const a = vyžadovať ('./ a');
a.on ('ready', () => {
  console.log ("modul" a "je pripravený");
});
Upozorňujeme, že priradenie k modulu.exporty sa musí vykonať okamžite. Nie je možné vykonať žiadne spätné volania. To nefunguje:

x.js:

setTimeout (() => {
  module.exports = {a: 'ahoj'};
}, 0);
y.js:

kon x = req
uire ( './ x');
console.log (x.a);
skratka exportu

Pridané v: v0.1.16

Premenná exportu je k dispozícii v rozsahu modulu na úrovni súboru a pred hodnotením modulu je priradená hodnota module.exportov.

Umožňuje skratku, takže modul.exports.f = ... môže byť napísaný stručne ako exports.f = .... Uvedomte si však, že ako každá premenná, ak je exportu priradená nová hodnota, je už nie je viazaný na module.exports:

module.exports.hello = true; // Vyexportované z požiadavky modulu
export = {hello: false}; // Neexportované, dostupné iba v module
Keď je vlastnosť modul.exports úplne nahradená novým objektom, je bežné aj exportovať exporty:

modul.exports = export = funkcia Constructor () {
  // ... atď.
};
Ak chcete ilustrovať toto správanie, predstavte si túto hypotetickú implementáciu požiadavky (), ktorá je celkom podobná tomu, čo skutočne vykonáva požiadavka ():

funkcia vyžadujú (/ * ... * /) {
  konst modul = {export: {}};
  ((modul, export) => {
    Kód modulu tu. V tomto príklade definujte funkciu.
    funkcia someFunc () {}
    export = someFunc;
    // V tomto okamihu už export nie je skratkou pre module.exporty a
    // tento modul bude exportovať prázdny predvolený objekt.
    module.exports = someFunc;
    // V tomto momente bude modul teraz exportovať someFunc namiesto
    // predvolený objekt.
  }) (modul, modul.exporty);
  návrat modul.exporty;
}
module.filename

Pridané v: v0.1.16

<String>
Plne vyriešený názov súboru do modulu.

module.id

Pridané v: v0.1.16

<String>
Identifikátor pre modul. Typicky je to plne vyriešený názov súboru.

module.loaded

Pridané v: v0.1.16

<Boolean>
Či je alebo nie je modul načítaný, alebo je v procese nakladania.

module.parent

Pridané v: v0.1.16

<Module>
Modul, ktorý to najprv vyžadoval.

module.paths

Pridané v: v0.4.0

<Reťazec []>
Vyhľadávacie cesty pre modul.

module.require (id)

Pridané v: v0.5.1

id <string>
Vráti: <modul> Object> module.exports z vyriešeného modulu
Metóda modul.require poskytuje spôsob, ako načítať modul, ako keby bol požadovaný (), bol z pôvodného modulu zavolaný.

Aby ste to dosiahli, je potrebné získať odkaz na objekt modulu. Vzhľadom na to, že require () vráti modul.exporty a modul je zvyčajne k dispozícii iba v rámci kódu konkrétneho modulu, musí byť explicitne exportovaný, aby mohol byť použitý.

Objekt modulu

Pridané v: v0.3.7

<Object>
Poskytuje všeobecné metódy použitia pri interakcii s inštanciami modulu - premenná modulu, ktorá sa často pozoruje v súborových moduloch. Prístup cez požiadavku ('modul').

module.builtinModules

Pridané v: v9.3.0

<Reťazec []>
Zoznam názvov všetkých modulov poskytnutých Node.js. Môže sa použiť na overenie, či je modul spravovaný treťou stranou alebo nie.

Všimnite si, že modul v tomto kontexte nie je ten istý objekt, ktorý poskytuje balík modulov. Na prístup k nej si vyžiadajte modul modulu:

const builtin = vyžadovať ('modul') builtinModules;